### PR TITLE
Update blog post authors

### DIFF
--- a/source/blog/2019-08-16-announcing-async-std.html.md
+++ b/source/blog/2019-08-16-announcing-async-std.html.md
@@ -2,7 +2,7 @@
 title: Announcing async-std
 date: 2019-08-16
 tags: release,announcement
-author: "Stjepan Glavina"
+author: "The async-std developers"
 ---
 
 We are excited to announce a beta release of `async-std` with the intent to publish version `1.0` by *September 26th, 2019*.

--- a/source/blog/2019-12-16-stop-worrying-about-blocking-the-new-async-std-runtime.html.md
+++ b/source/blog/2019-12-16-stop-worrying-about-blocking-the-new-async-std-runtime.html.md
@@ -2,7 +2,7 @@
 title: "Stop worrying about blocking: the new async-std runtime, inspired by Go"
 date: 2019-12-16
 tags: release,announcement,christmas
-author: "Stjepan Glavina"
+author: "The async-std developers"
 ---
 
 `async-std` is a mature and stable port of the Rust standard library to its new `async/await` world, designed to make async programming easy, efficient, worry- and error-free.


### PR DESCRIPTION
Updating the authors on blog posts attributed to me personally. I'm changing it to "The async-std developers" because they have only partially been written by me, and the project has been a big collaborative effort. It appears there has been some confusion among readers about "who did what" so I feel the change in this PR will help clear things up.

cc @skade